### PR TITLE
chore: drop Java 8 from build matric

### DIFF
--- a/.github/workflows/certified_images.yml
+++ b/.github/workflows/certified_images.yml
@@ -12,7 +12,7 @@ jobs:
     name: DockerHub
     strategy:
       matrix:
-        java: [8, 11, 17, 21, latest]
+        java: [11, 17, 21, latest]
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:


### PR DESCRIPTION
We no longer support Java 8.