### PR TITLE
Stop generating images for Java 11 and 17, close CLD-5929

### DIFF
--- a/.github/workflows/certified_images.yml
+++ b/.github/workflows/certified_images.yml
@@ -12,7 +12,7 @@ jobs:
     name: DockerHub
     strategy:
       matrix:
-        java: [11, 17, 21, latest]
+        java: [21, latest]
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:


### PR DESCRIPTION
Motivation:

We want to reduce the burden of maintaining so many images and encourage users to run with modern java.